### PR TITLE
Fix calculation parsing bugs and improve parser testing

### DIFF
--- a/lib/editor/parser.dart
+++ b/lib/editor/parser.dart
@@ -1,7 +1,9 @@
 import 'package:onyx/editor/model.dart';
 
+// For operators "+-*/" match the op (eg. ":+"), number (eg. "100,000"), and the text (eg. "cost")
+// For the equals operator (":="), do not match any named group, but still match the text as a whole.
 final mathematicalExpressionRegex =
-    RegExp(r'^(?<op>:[=+-/*]?)(?<num>[0-9]+([,.]?[0-9]+)?)?(?<text>.*)');
+    RegExp(r'^(:=)|(?<op>^:[+\-\/*]?)(?<num>[0-9]+([,.]?[0-9]+)?)(?<text>.*)');
 
 final operators = {
   ':-': Operator.subtract,
@@ -29,18 +31,19 @@ abstract class Parser {
     num? number;
 
     RegExpMatch? match = mathematicalExpressionRegex.firstMatch(source);
-
     if (match != null) {
-      operator = operators[match.namedGroup("op")] ?? Operator.add;
+      String? opGroupMatch = match.namedGroup("op");
 
-      if (operator != Operator.equals) {
-        number = num.tryParse(match.namedGroup("num") ?? "");
+      if (opGroupMatch != null) {
+        String? numGroupMatch = match.namedGroup("num");
+        String? textGroupMatch = match.namedGroup("text");
 
-        if (number != null) {
-          source = match.namedGroup("text")?.trim() ?? "";
-        }
+        operator = operators[opGroupMatch] ?? Operator.add;
+        number = num.tryParse(numGroupMatch ?? "");
+        source = textGroupMatch?.trim() ?? "";
       } else {
-        source = source.substring(match.namedGroup("op")?.length ?? 0);
+        operator = Operator.equals;
+        source = source.substring(2).trim();
       }
     }
 

--- a/lib/editor/parser.dart
+++ b/lib/editor/parser.dart
@@ -1,6 +1,15 @@
 import 'package:onyx/editor/model.dart';
 
-final expression = RegExp(r'^\:[0-9]+(([\.\,])+[0-9]+)?');
+final mathematicalExpressionRegex =
+    RegExp(r'^(?<op>:[=+-/*]?)(?<num>[0-9]+([,.]?[0-9]+)?)?(?<text>.*)');
+
+final operators = {
+  ':-': Operator.subtract,
+  ':+': Operator.add,
+  ':/': Operator.divide,
+  ':*': Operator.multiply,
+  ':=': Operator.equals,
+};
 
 abstract class Parser {
   static ListItemState parse(ListItemState model) {
@@ -17,33 +26,21 @@ abstract class Parser {
     updatedModel = updatedModel.copyWith(indent: parseIndent(model.fullText));
 
     Operator operator = Operator.none;
-
-    <String, Operator>{
-      ':-': Operator.subtract,
-      ':+': Operator.add,
-      ':/': Operator.divide,
-      ':*': Operator.multiply,
-      ':=': Operator.equals,
-    }.forEach((key, value) {
-      if (source.startsWith(key)) {
-        operator = value;
-      }
-    });
-
-    if (operator != Operator.none) {
-      source = ':${source.substring(2)}';
-    }
-
     num? number;
-    if (hasMatch(source)) {
-      var match = getMatch(source);
-      number = num.tryParse(match.substring(1));
-      if (number != null) {
-        updatedModel = updatedModel.copyWith(number: number);
-        if (operator == Operator.none) {
-          operator = Operator.add;
+
+    RegExpMatch? match = mathematicalExpressionRegex.firstMatch(source);
+
+    if (match != null) {
+      operator = operators[match.namedGroup("op")] ?? Operator.add;
+
+      if (operator != Operator.equals) {
+        number = num.tryParse(match.namedGroup("num") ?? "");
+
+        if (number != null) {
+          source = match.namedGroup("text")?.trim() ?? "";
         }
-        source = source.substring(getMatch(source).length).trim();
+      } else {
+        source = source.substring(match.namedGroup("op")?.length ?? 0);
       }
     }
 
@@ -54,16 +51,5 @@ abstract class Parser {
     );
 
     return updatedModel;
-  }
-
-  static bool hasMatch(String source) => expression.hasMatch(source);
-
-  static String getMatch(String source) {
-    final match = expression.firstMatch(source);
-    if (match != null) {
-      return source.substring(match.start, match.end);
-    } else {
-      return '';
-    }
   }
 }

--- a/test/parser_test.dart
+++ b/test/parser_test.dart
@@ -3,11 +3,9 @@ import 'package:onyx/editor/model.dart';
 import 'package:onyx/editor/parser.dart';
 
 void main() {
-  group('Parser', () {
-    test(
-        'correctly identifies and assigns operator when source starts with operator',
-        () {
-      const text = ':+ 5';
+  group('Calculation Parser', () {
+    test('correctly identifies operator when source starts with operator', () {
+      const text = ':+5';
       final model = ListItemState(
         index: 0,
         fullText: text,
@@ -24,6 +22,106 @@ void main() {
       expect(result.operator, Operator.add);
       expect(result.textPart, '');
       expect(result.number, 5);
+    });
+
+    test('does not identify operator if space between operator and number', () {
+      const text = ': 5';
+      final model = ListItemState(
+        index: 0,
+        fullText: text,
+        textPart: '',
+        checked: false,
+        operator: Operator.none,
+        number: 0,
+        indent: 0,
+        position: text.length,
+      );
+
+      final result = Parser.parse(model);
+
+      expect(result.operator, Operator.none);
+      expect(result.textPart, ': 5');
+      expect(result.number, 0);
+    });
+
+    test('correctly identifies operator with additional text', () {
+      const text = ':/2 description text';
+      final model = ListItemState(
+        index: 0,
+        fullText: text,
+        textPart: '',
+        checked: false,
+        operator: Operator.none,
+        number: 0,
+        indent: 0,
+        position: text.length,
+      );
+
+      final result = Parser.parse(model);
+
+      expect(result.operator, Operator.divide);
+      expect(result.textPart, 'description text');
+      expect(result.number, 2);
+    });
+
+    test('correctly identifies equals operator', () {
+      const text = ':=';
+      final model = ListItemState(
+        index: 0,
+        fullText: text,
+        textPart: '',
+        checked: false,
+        operator: Operator.none,
+        number: 0,
+        indent: 0,
+        position: text.length,
+      );
+
+      final result = Parser.parse(model);
+
+      expect(result.operator, Operator.equals);
+      expect(result.textPart, '');
+      expect(result.number, 0);
+    });
+
+    test('correctly identifies equals operator treating number as text', () {
+      const text = ':= 17 description';
+      final model = ListItemState(
+        index: 0,
+        fullText: text,
+        textPart: '',
+        checked: false,
+        operator: Operator.none,
+        number: 0,
+        indent: 0,
+        position: text.length,
+      );
+
+      final result = Parser.parse(model);
+
+      expect(result.operator, Operator.equals);
+      expect(result.textPart, '17 description');
+      expect(result.number, 0);
+    });
+
+    test('does not identify equals if space between operator and number', () {
+      const text = ': = description text';
+      final model = ListItemState(
+        index: 0,
+        fullText: text,
+        textPart: '',
+        checked: false,
+        operator: Operator.none,
+        number: 0,
+        indent: 0,
+        position: text.length,
+      );
+
+      final result = Parser.parse(model);
+
+      expect(result.operator, Operator.none);
+      expect(result.textPart, ': = description text');
+      expect(result.number, 0);
     });
 
     test('source string is empty or only whitespace', () {
@@ -44,8 +142,10 @@ void main() {
       expect(result.textPart, '');
       expect(result.number, 0);
     });
+  });
 
-    test('test indent paser', () {
+  group('Indent Parser', () {
+    test('test indent parser', () {
       const text = '    hello';
       final model = ListItemState(
         index: 0,


### PR DESCRIPTION
* Improve regex to more effectively identify the operator, number, and text components of calculation items.
  * Only match number and text components if the operator is valid avoiding null exceptions.
  * For **equals**, use a simple match (`^:=`) and `substring` so that all later characters are treated as text.
  * For **other operators**, use the "text" named group rather than `substring` for text extraction to fix the double displaying of numbers.
* Improve the testing of the parser.
  * Test with whitespace around the operator.
  * Specific tests for the equals operator.
  * Split calculation and indentation parsing into different test groups.
* Remove regex wrapper methods as the new expression only required one call to `firstMatch()`.