### PR TITLE
Fixed Visual bug: Settings title overlaps with menu button

### DIFF
--- a/lib/screens/settings.dart
+++ b/lib/screens/settings.dart
@@ -30,7 +30,7 @@ class SettingsScreen extends StatelessWidget {
     return Column(
       children: [
         Padding(
-          padding: const EdgeInsets.only(top: 16.0),
+          padding: const EdgeInsets.only(top: 30.0),
           child: ListTile(
             title: Text(
               'Settings',


### PR DESCRIPTION
Fixed the visual bug for settings title overlap by changing the padding of the Settings title