### PR TITLE
106 bug back button routes to loading page

### DIFF
--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -43,7 +43,7 @@ class NavigationMenu extends StatelessWidget {
                 maxWidth: false,
                 icon: const Icon(Icons.keyboard_arrow_left),
                 active: false,
-                onTap: state.index>0
+                onTap: context.read<NavigationCubit>().canUndo
                     ? () {
                         context.read<NavigationCubit>().undo();
                       }

--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -43,7 +43,7 @@ class NavigationMenu extends StatelessWidget {
                 maxWidth: false,
                 icon: const Icon(Icons.keyboard_arrow_left),
                 active: false,
-                onTap: context.read<NavigationCubit>().canUndo
+                onTap: state.index>0
                     ? () {
                         context.read<NavigationCubit>().undo();
                       }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -135,6 +135,9 @@ class _OnyxAppState extends State<OnyxApp> {
                     context.read<PageCubit>().index(-1);
                   }
                 }
+                if(currentPage == null && state is NavigationInitial){
+                  context.read<NavigationCubit>().redo();
+                }
               },
               builder: (context, state) => state is NavigationSuccess
                   ? HomeScreen(state: state)


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/bb3d442c-65d4-487d-9b98-1216dcfb651f)

I have fixed the issue with the back button by adding the marked if condition. If the state goes to navigationintial the cubit will execute redo and prevent from going to the loading screen.

closes #106