### PR TITLE
Bugfix: Shortcuts not working with Linux meta key

### DIFF
--- a/lib/central/help.dart
+++ b/lib/central/help.dart
@@ -1,5 +1,6 @@
 import 'package:onyx/widgets/button.dart';
 import 'package:flutter/material.dart';
+import 'dart:io' show Platform;
 
 void openHelpMenu(BuildContext context) => showDialog(
       context: context,
@@ -11,6 +12,8 @@ class HelpMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final modifierSymbol = Platform.isMacOS ? '⌘' : '⌃';
+
     return AlertDialog(
       content: ConstrainedBox(
         constraints: const BoxConstraints(
@@ -18,7 +21,7 @@ class HelpMenu extends StatelessWidget {
           minWidth: 350, // TODO adaptive width
           maxHeight: 650,
         ),
-        child: const SingleChildScrollView(
+        child: SingleChildScrollView(
           child: Column(
             mainAxisSize: MainAxisSize.min,
             children: [
@@ -32,26 +35,28 @@ class HelpMenu extends StatelessWidget {
               ListTile(
                 dense: true,
                 title: Text('Search pages and journals'),
-                leading: Text('⌘K'),
+                leading: Text('$modifierSymbol K'),
               ),
               ListTile(
                 dense: true,
                 title: Text('Manually synchronize'),
-                leading: Text('⌘S'),
+                leading: Text('$modifierSymbol S'),
               ),
               ListTile(
-                  dense: true,
-                  title: Text('Open help menu'),
-                  leading: Text('⌘H')),
+                dense: true,
+                title: Text('Open help menu'),
+                leading: Text('$modifierSymbol H'),
+              ),
               ListTile(
                 dense: true,
                 title: Text('Next journal'),
-                leading: Text('⌘↑'),
+                leading: Text('$modifierSymbol ↑'),
               ),
               ListTile(
-                  dense: true,
-                  title: Text('Previous journal'),
-                  leading: Text('⌘↓')),
+                dense: true,
+                title: Text('Previous journal'),
+                leading: Text('$modifierSymbol↓'),
+              ),
               ListTile(
                 title: Text(
                   'Editing',
@@ -62,17 +67,17 @@ class HelpMenu extends StatelessWidget {
               ListTile(
                 dense: true,
                 title: Text('Undo change'),
-                leading: Text('⌘Z'),
+                leading: Text('${modifierSymbol}Z'),
               ),
               ListTile(
                 dense: true,
                 title: Text('Redo change'),
-                leading: Text('⌘⇧Z'),
+                leading: Text('$modifierSymbol⇧Z'),
               ),
               ListTile(
                 dense: true,
                 title: Text('Delete line'),
-                leading: Text('⌘⌫'),
+                leading: Text('$modifierSymbol⌫'),
               ),
               ListTile(
                 dense: true,
@@ -82,7 +87,7 @@ class HelpMenu extends StatelessWidget {
               ListTile(
                 dense: true,
                 title: Text('Add new paragraph'),
-                leading: Text('⌘⏎'),
+                leading: Text('$modifierSymbol⏎'),
               ),
               ListTile(
                 dense: true,
@@ -107,17 +112,17 @@ class HelpMenu extends StatelessWidget {
               ListTile(
                 dense: true,
                 title: Text('Insert image ![alt](href)'),
-                leading: Text('⌘I'),
+                leading: Text('${modifierSymbol}I'),
               ),
               ListTile(
                 dense: true,
                 title: Text('Insert internal link/reference [[title]]'),
-                leading: Text('⌘R'),
+                leading: Text('${modifierSymbol}R'),
               ),
               ListTile(
                 dense: true,
                 title: Text('Insert external link [text](href)'),
-                leading: Text('⌘L'),
+                leading: Text('${modifierSymbol}L'),
               ),
               // arrows ↑ ↓ → ←
               // tab ⇥

--- a/lib/central/keyboard.dart
+++ b/lib/central/keyboard.dart
@@ -5,6 +5,7 @@ import 'package:onyx/central/search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'dart:io' show Platform;
 
 class SearchIntent extends ActivateIntent {
   const SearchIntent();
@@ -83,41 +84,32 @@ class KeyboardInterceptor extends StatelessWidget {
   Widget build(BuildContext context) {
     final cubit = context.read<PageCubit>();
     final navCubit = context.read<NavigationCubit>();
+
+    final modifierKey = Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.control;
+
     return Shortcuts(
       shortcuts: <LogicalKeySet, Intent>{
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyK):
-            const SearchIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.delete):
-            const DeleteLineIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyS):
-            const SyncIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyH):
-            const HelpIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyZ):
-            const UndoIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyK): const SearchIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.delete): const DeleteLineIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyS): const SyncIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyH): const HelpIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyZ): const UndoIntent(),
         LogicalKeySet(
-          LogicalKeyboardKey.meta,
+          modifierKey,
           LogicalKeyboardKey.shift,
           LogicalKeyboardKey.keyZ,
         ): const RedoIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.enter): const CreateNewLineIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyI): const ImageInsertIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.arrowUp): const NextJournalIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.arrowDown): const PreviousJournalIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyR): const PageInsertIntent(),
+        LogicalKeySet(modifierKey, LogicalKeyboardKey.keyL): const LinkInsertIntent(),
         LogicalKeySet(LogicalKeyboardKey.arrowUp): const LineUpIntent(),
         LogicalKeySet(LogicalKeyboardKey.arrowDown): const LineDownIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.enter):
-            const CreateNewLineIntent(),
         LogicalKeySet(LogicalKeyboardKey.enter): const LineFeedIntent(),
         LogicalKeySet(LogicalKeyboardKey.tab): const IndentIncreaseIntent(),
-        LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab):
-            const IndentDecreaseIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyI):
-            const ImageInsertIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowUp):
-            const NextJournalIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.arrowDown):
-            const PreviousJournalIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyR):
-            const PageInsertIntent(),
-        LogicalKeySet(LogicalKeyboardKey.meta, LogicalKeyboardKey.keyL):
-            const LinkInsertIntent(),
+        LogicalKeySet(LogicalKeyboardKey.shift, LogicalKeyboardKey.tab): const IndentDecreaseIntent(),
       },
       child: Actions(
         actions: <Type, Action<Intent>>{

--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -1,4 +1,3 @@
-import 'package:onyx/central/conflict.dart';
 import 'package:onyx/central/favorites.dart';
 import 'package:onyx/central/help.dart';
 import 'package:onyx/central/recents.dart';
@@ -8,6 +7,7 @@ import 'package:onyx/central/search.dart';
 import 'package:onyx/widgets/button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'dart:io' show Platform;
 
 class NavigationMenu extends StatelessWidget {
   final NavigationSuccess state;
@@ -16,8 +16,10 @@ class NavigationMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final modifierSymbol = Platform.isMacOS ? '⌘' : '⌃';
+
     return Container(
-      width: 200,
+      width: 224,
       decoration: const BoxDecoration(),
       padding: const EdgeInsets.all(12),
       child: Column(
@@ -126,7 +128,7 @@ class NavigationMenu extends StatelessWidget {
                 ),
               ),
               Button(
-                '⌘K',
+                '${modifierSymbol}K',
                 width: 84,
                 height: 40,
                 iconSize: 14,
@@ -206,8 +208,8 @@ class NavigationMenu extends StatelessWidget {
                 ),
               ),
               Button(
-                '⌘',
-                width: 60,
+                '${modifierSymbol}H',
+                width: 84,
                 iconSize: 18,
                 maxWidth: false,
                 icon: const Icon(Icons.help_outline_outlined),

--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -84,7 +84,6 @@ class NavigationMenu extends StatelessWidget {
                       children: [
                         Button(
                           'Sync',
-                          width: 84,
                           height: 40,
                           iconSize: 14,
                           maxWidth: false,
@@ -113,7 +112,7 @@ class NavigationMenu extends StatelessWidget {
                         ),
                         Positioned(
                             top: 0,
-                            right: 8,
+                            right: 0,
                             child: Container(
                               height: 12,
                               width: 12,
@@ -132,7 +131,7 @@ class NavigationMenu extends StatelessWidget {
                 width: 84,
                 height: 40,
                 iconSize: 14,
-                maxWidth: true,
+                maxWidth: false,
                 icon: const Icon(Icons.search),
                 active: false,
                 onTap: () {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -166,7 +166,7 @@ class _OnyxAppState extends State<OnyxApp> {
                     context.read<PageCubit>().index(0);
                   }
                 }
-                if(currentPage == null && state is NavigationInitial){
+                if (currentPage == null && state is NavigationInitial) {
                   context.read<NavigationCubit>().redo();
                 }
               },
@@ -202,7 +202,7 @@ class _HomeScreenState extends State<HomeScreen> {
             borderRadius: BorderRadius.circular(0),
             side: BorderSide.none,
           ),
-          width: 200,
+          width: 224,
           child: SafeArea(
             child: NavigationMenu(
               state: widget.state,


### PR DESCRIPTION
* Shortcuts on non-Mac platforms now use control as the modifier key.
* Button text has been changed to reflect this, using ⌃ instead of ⌘ to represent control.
* Change spacing between sync and search buttons to match settings and help below.