### PR TITLE
77 add calendar overview to journals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@
 .svn/
 .swiftpm/
 migrate_working_dir/
+android/app/.cxx/
 
 # IntelliJ related
 *.iml

--- a/lib/central/body.dart
+++ b/lib/central/body.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:onyx/cubit/navigation_cubit.dart';
+import 'package:onyx/screens/calendarview.dart';
 import 'package:onyx/screens/journals.dart';
 import 'package:onyx/screens/pages.dart';
 import 'package:onyx/screens/settings.dart';
@@ -18,6 +19,7 @@ class Body extends StatelessWidget {
           RouteState.pages => const PagesScreen(),
           RouteState.pageSelected => const PagesScreen(),
           RouteState.settings => const SettingsScreen(),
+          RouteState.calendarview =>  const CalendarViewScreen(),
         };
       } else {
         return Container();

--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -178,6 +178,17 @@ class NavigationMenu extends StatelessWidget {
               context.read<NavigationCubit>().navigateTo(RouteState.pages);
             },
           ),
+           Button(
+            'Calendar View',
+            height: 40,
+            maxWidth: true,
+            icon: const Icon(Icons.calendar_month),
+            active: state.pagesNav,
+            onTap: () {
+              onTapCollapse();
+              context.read<NavigationCubit>().navigateTo(RouteState.calendarview);
+            },
+          ),
           Divider(
             height: 12,
             endIndent: 0,

--- a/lib/cubit/navigation_cubit.dart
+++ b/lib/cubit/navigation_cubit.dart
@@ -14,6 +14,7 @@ enum RouteState {
   pages,
   pageSelected,
   journalSelected,
+  calendarview,
   settings,
 }
 
@@ -27,6 +28,8 @@ class NavigationSuccess extends NavigationState {
   bool get pagesNav => route == RouteState.pageSelected || route == RouteState.pages;
 
   bool get settingsNav => route == RouteState.settings;
+
+  bool get calendarViewNav => route == RouteState.calendarview;
 
   NavigationSuccess({
     required this.route,
@@ -235,6 +238,17 @@ class NavigationCubit extends ReplayCubit<NavigationState> {
     }
   }
 
+  void openJournalFromCalendar(String text){
+    final journal = store.journals.values.firstWhereOrNull((e) => e.title == text)?.uid;
+      if (journal != null) {
+        switchToJournal(journal);
+      }
+      else{
+        PageState pagestate = store.getJournal(text).toPageState(true);
+        switchToJournal(pagestate.uid);
+      }
+  }
+
   void openPageOrJournal(String text) {
     final page = store.pages.values.firstWhereOrNull((e) => e.title == text)?.uid;
     if (page != null) {
@@ -255,6 +269,7 @@ class NavigationCubit extends ReplayCubit<NavigationState> {
         RouteState.pageSelected => store.getPage(currentState.pageId ?? '')?.toPageState(false),
         RouteState.journalSelected => store.getJournal(currentState.pageId ?? '').toPageState(true),
         RouteState.settings => null,
+        RouteState.calendarview => null
       };
     } else {
       return null;

--- a/lib/editor/item.dart
+++ b/lib/editor/item.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
@@ -240,7 +241,7 @@ class _ListItemEditorState extends State<ListItemEditor> {
             if (widget.inFocus)
               Expanded(
                 child: TextField(
-                  textInputAction: Platform.isIOS || Platform.isAndroid ? TextInputAction.done : TextInputAction.none,
+                  textInputAction: defaultTargetPlatform == TargetPlatform.iOS || defaultTargetPlatform == TargetPlatform.android ? TextInputAction.done : TextInputAction.none,
                   minLines: 1,
                   maxLines: 100,
                   cursorColor: Colors.black,

--- a/lib/screens/calendarview.dart
+++ b/lib/screens/calendarview.dart
@@ -1,0 +1,155 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:onyx/cubit/navigation_cubit.dart';
+import 'package:onyx/cubit/page_cubit.dart';
+import 'package:syncfusion_flutter_calendar/calendar.dart';
+
+class CalendarViewScreen extends StatelessWidget {
+  const CalendarViewScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<PageCubit, PageState>(
+      builder: (context, state) {
+        return CalendarViewPage();
+      },
+    );
+  }
+}
+
+class CalendarViewPage extends StatefulWidget {
+  @override
+  _CalendarViewPageState createState() => _CalendarViewPageState();
+}
+
+class _CalendarViewPageState extends State<CalendarViewPage> {
+  final Set<DateTime> _journalDates = {};
+  final Map<DateTime, String> _dateTitleMap = {};
+
+  @override
+  void initState() {
+    super.initState();
+    final pageCubit = context.read<PageCubit>();
+
+    for (int i = 0; i < pageCubit.store.journalLength; i++) {
+      final pageModel = pageCubit.store.journals.values.elementAt(i);
+      if (pageModel.title.isNotEmpty) {
+        final pageState = pageModel.toPageState(true);
+        if (pageState.items.length > 1 || (pageState.items.length==1 && pageState.items.elementAt(0).fullText!="")) {
+          try {
+            List<String> parts = pageModel.title.split("/");
+            DateTime date = DateTime(
+              int.parse(parts[2]),
+              int.parse(parts[1]),
+              int.parse(parts[0]),
+            );
+            final normalized = _normalizeDate(date);
+            _journalDates.add(normalized);
+            _dateTitleMap[normalized] = pageModel.title;
+          } catch (_) {
+            // Skip malformed entries
+          }
+        }
+      }
+    }
+  }
+
+  DateTime _normalizeDate(DateTime dt) => DateTime(dt.year, dt.month, dt.day);
+
+  String getStringTitle(DateTime dt) {
+    final day = dt.day.toString().padLeft(2, '0');
+    final month = dt.month.toString().padLeft(2, '0');
+    return '$day/$month/${dt.year}';
+  }
+
+  bool _isJournaled(DateTime day) => _journalDates.contains(_normalizeDate(day));
+
+  @override
+  Widget build(BuildContext context) {
+    final screenHeight = MediaQuery.of(context).size.height;
+
+    return Scaffold(
+      body: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          children: [
+            Text(
+              "Journal Calendar",
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              height: screenHeight * 0.8, // 50% of the screen height
+              child: SfCalendar(
+                view: CalendarView.month,
+                initialSelectedDate: DateTime.now(),
+                showNavigationArrow: true,
+                showDatePickerButton: true,
+                todayHighlightColor: Colors.deepPurple,
+                monthCellBuilder: (BuildContext context, MonthCellDetails details) {
+                  final normalized = _normalizeDate(details.date);
+                  final isJournaled = _isJournaled(normalized);
+
+                  return Container(
+                    margin: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: isJournaled
+                          ? Colors.indigo
+                          : details.date.isBefore(DateTime.now())
+                              ? Colors.grey.withValues(alpha: 0.3)
+                              : null,
+                    ),
+                    alignment: Alignment.center,
+                    child: Column(
+                      mainAxisAlignment: MainAxisAlignment.center,
+                      children: [
+                        Text(
+                          '${details.date.day}',
+                          style: TextStyle(
+                            color: isJournaled ? Colors.white : Colors.black,
+                            fontWeight: FontWeight.w500,
+                          ),
+                        ),
+                        if (isJournaled)
+                          Icon(
+                            Icons.edit, // Pencil icon for journaled days
+                            size: 16,
+                            color: Colors.white, // White icon for visibility on blue background
+                          ),
+                        if (!isJournaled)
+                          Icon(
+                            Icons.add_circle_outline, // Pencil icon for journaled days
+                            size: 16,
+                            color:Colors.black, // White icon for visibility on blue background
+                          ),
+                      ],
+                    ),
+                  );
+                },
+                onTap: (calendarTapDetails) {
+                  final tappedDate = calendarTapDetails.date;
+                  if (tappedDate == null) return;
+
+                  final normalized = _normalizeDate(tappedDate);
+                  print(normalized);
+                  if (_dateTitleMap.containsKey(normalized)) {
+                    context.read<NavigationCubit>().openPageOrJournal(_dateTitleMap[normalized]!);
+                  } else {
+                    context.read<NavigationCubit>().openJournalFromCalendar(getStringTitle(normalized));
+                  }
+                },
+                monthViewSettings: const MonthViewSettings(
+                  showTrailingAndLeadingDates: false,
+                  dayFormat: 'EEE',
+                  showAgenda: false,
+                ),
+              ),
+            ),
+            // You can add more widgets here if needed
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/calendarview.dart
+++ b/lib/screens/calendarview.dart
@@ -35,7 +35,7 @@ class _CalendarViewPageState extends State<CalendarViewPage> {
       final pageModel = pageCubit.store.journals.values.elementAt(i);
       if (pageModel.title.isNotEmpty) {
         final pageState = pageModel.toPageState(true);
-        if (pageState.items.length > 1 || (pageState.items.length==1 && pageState.items.elementAt(0).fullText!="")) {
+        if (pageState.items.length > 1 || (pageState.items.length == 1 && pageState.items.elementAt(0).fullText != "")) {
           try {
             List<String> parts = pageModel.title.split("/");
             DateTime date = DateTime(
@@ -79,7 +79,7 @@ class _CalendarViewPageState extends State<CalendarViewPage> {
             ),
             const SizedBox(height: 12),
             SizedBox(
-              height: screenHeight * 0.8, // 50% of the screen height
+              height: screenHeight * 0.8,
               child: SfCalendar(
                 view: CalendarView.month,
                 initialSelectedDate: DateTime.now(),
@@ -113,15 +113,15 @@ class _CalendarViewPageState extends State<CalendarViewPage> {
                         ),
                         if (isJournaled)
                           Icon(
-                            Icons.edit, // Pencil icon for journaled days
+                            Icons.edit,
                             size: 16,
-                            color: Colors.white, // White icon for visibility on blue background
+                            color: Colors.white,
                           ),
                         if (!isJournaled)
                           Icon(
-                            Icons.add_circle_outline, // Pencil icon for journaled days
+                            Icons.add_circle_outline,
                             size: 16,
-                            color:Colors.black, // White icon for visibility on blue background
+                            color: Colors.black,
                           ),
                       ],
                     ),
@@ -130,9 +130,7 @@ class _CalendarViewPageState extends State<CalendarViewPage> {
                 onTap: (calendarTapDetails) {
                   final tappedDate = calendarTapDetails.date;
                   if (tappedDate == null) return;
-
                   final normalized = _normalizeDate(tappedDate);
-                  print(normalized);
                   if (_dateTitleMap.containsKey(normalized)) {
                     context.read<NavigationCubit>().openPageOrJournal(_dateTitleMap[normalized]!);
                   } else {
@@ -146,7 +144,6 @@ class _CalendarViewPageState extends State<CalendarViewPage> {
                 ),
               ),
             ),
-            // You can add more widgets here if needed
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,7 @@ dependencies:
   hive_ce_flutter: ^2.2.0
   hive_ce: ^2.10.1
   build_runner: ^2.4.15
+  syncfusion_flutter_calendar: ^29.1.41
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
A calendar overview is added as per the acceptance criteria mentioned in the story.

1. Open Journals for any date on the calendar.
2. The date for which journals are written is highlighted.
3. Previous dates for which journals are not written are also highlighted

Link to the video demonstration: 
https://rmiteduau-my.sharepoint.com/:v:/g/personal/s3998327_student_rmit_edu_au/EYZwNXKfXZZCgwz4Akqs17QBuwwu_6oAqixFNggzkuZS4g?nav=eyJyZWZlcnJhbEluZm8iOnsicmVmZXJyYWxBcHAiOiJTdHJlYW1XZWJBcHAiLCJyZWZlcnJhbFZpZXciOiJTaGFyZURpYWxvZy1MaW5rIiwicmVmZXJyYWxBcHBQbGF0Zm9ybSI6IldlYiIsInJlZmVycmFsTW9kZSI6InZpZXcifX0%3D&e=VDQI5O