### PR TITLE
fixing the reintroduced Unsupported operation: Platform._operatingSystem bug

### DIFF
--- a/lib/central/help.dart
+++ b/lib/central/help.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:onyx/widgets/button.dart';
 import 'package:flutter/material.dart';
-import 'dart:io' show Platform;
 
 void openHelpMenu(BuildContext context) => showDialog(
       context: context,
@@ -12,7 +12,7 @@ class HelpMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final modifierSymbol = Platform.isMacOS ? '⌘' : '⌃';
+    final modifierSymbol = defaultTargetPlatform == TargetPlatform.macOS ? '⌘' : '⌃';
 
     return AlertDialog(
       content: ConstrainedBox(

--- a/lib/central/keyboard.dart
+++ b/lib/central/keyboard.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:onyx/central/help.dart';
 import 'package:onyx/cubit/navigation_cubit.dart';
 import 'package:onyx/cubit/page_cubit.dart';
@@ -5,7 +6,6 @@ import 'package:onyx/central/search.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'dart:io' show Platform;
 
 class SearchIntent extends ActivateIntent {
   const SearchIntent();
@@ -85,7 +85,7 @@ class KeyboardInterceptor extends StatelessWidget {
     final cubit = context.read<PageCubit>();
     final navCubit = context.read<NavigationCubit>();
 
-    final modifierKey = Platform.isMacOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.control;
+    final modifierKey = defaultTargetPlatform == TargetPlatform.macOS ? LogicalKeyboardKey.meta : LogicalKeyboardKey.control;
 
     return Shortcuts(
       shortcuts: <LogicalKeySet, Intent>{

--- a/lib/central/navigation.dart
+++ b/lib/central/navigation.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:onyx/central/favorites.dart';
 import 'package:onyx/central/help.dart';
 import 'package:onyx/central/recents.dart';
@@ -7,7 +8,6 @@ import 'package:onyx/central/search.dart';
 import 'package:onyx/widgets/button.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'dart:io' show Platform;
 
 class NavigationMenu extends StatelessWidget {
   final NavigationSuccess state;
@@ -16,7 +16,7 @@ class NavigationMenu extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final modifierSymbol = Platform.isMacOS ? '⌘' : '⌃';
+    final modifierSymbol = defaultTargetPlatform == TargetPlatform.macOS ? '⌘' : '⌃';
 
     return Container(
       width: 224,


### PR DESCRIPTION
**Platform.isMacOS**  was replaced with 
**defaultTargetPlatform == TargetPlatform.macOS** 
wherever the issue was observed
closes #132